### PR TITLE
Add create, start, destroy sandbox actions

### DIFF
--- a/epicbox/sandboxes.py
+++ b/epicbox/sandboxes.py
@@ -3,9 +3,7 @@ import tarfile
 import time
 import uuid
 from contextlib import contextmanager
-from functools import partial
 
-import dateutil.parser
 import structlog
 from docker.errors import APIError, DockerException, NotFound
 from requests.exceptions import RequestException
@@ -16,39 +14,203 @@ __all__ = ['run', 'working_directory']
 
 logger = structlog.get_logger()
 
+_SANDBOX_NAME_PREFIX = 'epicbox-'
 
-def run(profile_name, command=None, files=None, stdin=None, limits=None,
-        workdir=None):
-    """Run a new sandbox container.
 
-    :raises DockerError: if an error occurred with the underlying
-                         docker system
+class _SandboxContext(dict):
+    """A context manager wrapper for a sandbox container that destroys
+    it upon completion of the block."""
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        destroy(self)
+
+
+def create(profile_name, command=None, files=None, limits=None, workdir=None):
+    """Create a new sandbox container without starting it.
+
+    :param str profile_name: One of configured profile names.
+    :param str command: A command with args to run in the sandbox container.
+    :param list files: A list of `{'name': 'filename', 'content': b'data'}`
+        dicts which define files to be written to the working directory
+        of the sandbox.
+    :param dict limits: Specify time and memory limits for the sandboxed
+        process.  It overrides the default limits from `config.DEFAULT_LIMITS`.
+    :param workdir: A working directory created using `working_directory`
+                    context manager.
+    :return dict: A sandbox object.
+
+    :raises DockerError: If an error occurred with the underlying
+                         docker system.
     """
     if profile_name not in config.PROFILES:
-        # TODO: treat name as docker image
         raise ValueError("Profile not found: {0}".format(profile_name))
     if workdir is not None and not isinstance(workdir, _WorkingDirectory):
-        raise ValueError("Invalid `workdir`, it should be created using "
-                         "`working_directory` context manager")
+        raise ValueError("Invalid 'workdir', it should be created using "
+                         "'working_directory' context manager")
     profile = config.PROFILES[profile_name]
     command = command or profile.command or 'true'
+    command_list = ['/bin/sh', '-c', command]
+    limits = utils.merge_limits_defaults(limits)
+    c = _create_sandbox_container(profile.docker_image, command_list, limits,
+                                  workdir=workdir, user=profile.user,
+                                  read_only=profile.read_only,
+                                  network_disabled=profile.network_disabled)
+    if workdir and not workdir.node:
+        node_name = utils.inspect_container_node(c)
+        if node_name:
+            # Assign a Swarm node name to the working directory to run
+            # subsequent containers on this same node.
+            workdir.node = node_name
+            logger.info("Assigned Swarm node to the working directory",
+                        workdir=workdir)
+    if files:
+        _write_files(c, files)
+    sandbox = _SandboxContext(c)
+    # Store the realtime limit in the sandbox structure to access it later
+    # in `start` function.
+    sandbox['RealtimeLimit'] = limits['realtime']
+    logger.info("Sandbox prepared and ready to start", sandbox=sandbox)
+    return sandbox
+
+
+def _create_sandbox_container(image, command, limits, workdir=None, user=None,
+                              read_only=False, network_disabled=True):
+    sandbox_id = str(uuid.uuid4())
+    name = _SANDBOX_NAME_PREFIX + sandbox_id
+    mem_limit = str(limits['memory']) + 'm'
+    binds = {
+        workdir.volume: {
+            'bind': config.DOCKER_WORKDIR,
+            'ro': False,
+        }
+    } if workdir else None
+    ulimits = utils.create_ulimits(limits)
+    docker_client = utils.get_docker_client()
+    host_config = docker_client.create_host_config(binds=binds,
+                                                   read_only=read_only,
+                                                   mem_limit=mem_limit,
+                                                   memswap_limit=mem_limit,
+                                                   ulimits=ulimits,
+                                                   log_config={'type': 'none'})
+    environment = None
+    if workdir and workdir.node:
+        # Add constraint to run a container on the Swarm node that
+        # ran the first container with this working directory.
+        environment = ['constraint:node==' + workdir.node]
+    log = logger.bind(sandbox_id=sandbox_id)
+    log.info("Creating a new sandbox container", name=name, image=image,
+             command=command, limits=limits, workdir=workdir, user=user,
+             read_only=read_only, network_disabled=network_disabled)
+    try:
+        c = docker_client.create_container(image,
+                                           command=command,
+                                           user=user,
+                                           stdin_open=True,
+                                           environment=environment,
+                                           network_disabled=network_disabled,
+                                           name=name,
+                                           working_dir=config.DOCKER_WORKDIR,
+                                           host_config=host_config)
+    except (RequestException, DockerException) as e:
+        if isinstance(e, APIError) and e.response.status_code == 409:
+            # This may happen because of retries, it's a recoverable error
+            log.info("The container with the given name is already created",
+                     name=name)
+            c = {'Id': name}
+        else:
+            log.exception("Failed to create a sandbox container")
+            raise exceptions.DockerError(str(e))
+    log.info("Sandbox container created", container=c)
+    return c
+
+
+def start(sandbox, stdin=None):
+    """Start a created sandbox container and wait for it to terminate.
+
+    :param sandbox: A sandbox to start.
+    :param bytes stdin: The data to be sent to the standard input of the
+                        sandbox, or `None`, if no data should be sent.
+
+    :return dict: A result structure containing the exit code of the sandbox,
+        its stdout and stderr output, duration of execution, etc.
+
+    :raises DockerError: If an error occurred with the underlying
+                         docker system.
+    """
     if stdin:
         if not isinstance(stdin, (bytes, str)):
             raise TypeError("'stdin' must be bytes or str")
         if isinstance(stdin, str):
             stdin = stdin.encode()
-    command_list = ['/bin/sh', '-c', command]
-    limits = utils.merge_limits_defaults(limits)
+    realtime_limit = sandbox.get('RealtimeLimit')
+    log = logger.bind(sandbox=sandbox)
+    log.info("Starting the sandbox container", stdin_size=len(stdin or ''))
+    result = {
+        'exit_code': None,
+        'stdout': b'',
+        'stderr': b'',
+        'duration': None,
+        'timeout': False,
+        'oom_killed': False,
+    }
+    try:
+        stdout, stderr = utils.docker_communicate(sandbox, stdin=stdin,
+                                                  timeout=realtime_limit)
+    except TimeoutError:
+        log.info("Sandbox realtime limit exceeded", realtime=realtime_limit)
+        result['timeout'] = True
+    except (RequestException, DockerException, OSError) as e:
+        log.exception("Sandbox runtime error")
+        raise exceptions.DockerError(str(e))
+    else:
+        log.info("Sandbox container exited")
+        state = utils.inspect_container_state(sandbox)
+        result.update(stdout=stdout, stderr=stderr, **state)
+        if (utils.is_killed_by_sigkill_or_sigxcpu(state['exit_code']) and
+                not state['oom_killed']):
+            # SIGKILL/SIGXCPU is sent but not by out of memory killer
+            result['timeout'] = True
+    log.info("Sandbox run result", result=utils.truncate_result(result))
+    return result
 
-    start_sandbox = partial(
-        _start_sandbox, profile.docker_image, command_list, limits,
-        files=files, stdin=stdin, workdir=workdir, user=profile.user,
-        read_only=profile.read_only, network_disabled=profile.network_disabled)
-    if files and not workdir:
-        with working_directory() as workdir:
-            return start_sandbox(workdir=workdir)
-    return start_sandbox()
+
+def destroy(sandbox):
+    """Destroy a sandbox container.
+
+    Kill a running sandbox before removal.  Remove the volumes auto-created
+    and associated with the sandbox container.
+
+    :param sandbox: A sandbox to destroy.
+    """
+    docker_client = utils.get_docker_client()
+    try:
+        docker_client.remove_container(sandbox, v=True, force=True)
+    except (RequestException, DockerException):
+        logger.exception("Failed to destroy the sandbox container",
+                         sandbox=sandbox)
+    else:
+        logger.info("Sandbox container destroyed", sandbox=sandbox)
+
+
+def run(profile_name, command=None, files=None, stdin=None, limits=None,
+        workdir=None):
+    """Run a command in a new sandbox container and wait for it to finish
+    running.  Destroy the sandbox when it has finished running.
+
+    The arguments to this function is a combination of arguments passed
+    to `create` and `start` functions.
+
+    :return dict: Same as for `start`.
+
+    :raises DockerError: If an error occurred with the underlying
+                         docker system.
+    """
+    with create(profile_name, command=command, files=files, limits=limits,
+                workdir=workdir) as sandbox:
+        return start(sandbox, stdin=stdin)
 
 
 class _WorkingDirectory(object):
@@ -122,146 +284,3 @@ def _write_files(container, files):
         raise exceptions.DockerError(str(e))
     log.info("Successfully written files to the working directory",
              files_written=files_written)
-
-
-def _inspect_container_state(container):
-    docker_client = utils.get_docker_client()
-    try:
-        container_info = docker_client.inspect_container(container)
-    except (RequestException, DockerException) as e:
-        logger.exception("Failed to inspect the container",
-                         container=container)
-        raise exceptions.DockerError(str(e))
-    started_at = dateutil.parser.parse(container_info['State']['StartedAt'])
-    finished_at = dateutil.parser.parse(container_info['State']['FinishedAt'])
-    duration = finished_at - started_at
-    duration_seconds = duration.total_seconds()
-    if duration_seconds < 0:
-        duration_seconds = -1
-    return {
-        'exit_code': container_info['State']['ExitCode'],
-        'duration': duration_seconds,
-        'oom_killed': container_info['State'].get('OOMKilled', False),
-    }
-
-
-def _inspect_container_node(container):
-    # 404 No such container may be returned when TimeoutError occurs
-    # on container creation.
-    docker_client = utils.get_docker_client(retry_status_forcelist=(404, 500))
-    try:
-        container_info = docker_client.inspect_container(container)
-    except (RequestException, DockerException) as e:
-        logger.exception("Failed to inspect the container",
-                         container=container)
-        raise exceptions.DockerError(str(e))
-    if 'Node' not in container_info:
-        # Remote Docker side is not a Docker Swarm cluster
-        return None
-    return container_info['Node']['Name']
-
-
-def _start_sandbox(image, command, limits, files=None, stdin=None,
-                   workdir=None, user=None, read_only=False,
-                   network_disabled=True):
-    # TODO: clean up a sandbox in case of errors (fallback/periodic task)
-    sandbox_id = str(uuid.uuid4())
-    name = 'epicbox-' + sandbox_id
-    mem_limit = str(limits['memory']) + 'm'
-
-    binds = {
-        workdir.volume: {
-            'bind': config.DOCKER_WORKDIR,
-            'ro': False,
-        }
-    } if workdir else None
-    ulimits = utils.create_ulimits(limits)
-    docker_client = utils.get_docker_client()
-    host_config = docker_client.create_host_config(binds=binds,
-                                                   read_only=read_only,
-                                                   mem_limit=mem_limit,
-                                                   memswap_limit=mem_limit,
-                                                   ulimits=ulimits,
-                                                   log_config={'type': 'none'})
-    environment = None
-    if workdir and workdir.node:
-        # Add constraint to run a container on the Swarm node that
-        # ran the first container with this working directory.
-        environment = ['constraint:node==' + workdir.node]
-    log = logger.bind(sandbox_id=sandbox_id)
-    log.info("Starting new sandbox", name=name, image=image, command=command,
-             limits=limits, workdir=workdir, user=user,
-             read_only=read_only, network_disabled=network_disabled)
-    try:
-        c = docker_client.create_container(image,
-                                           command=command,
-                                           user=user,
-                                           stdin_open=bool(stdin),
-                                           environment=environment,
-                                           network_disabled=network_disabled,
-                                           name=name,
-                                           working_dir=config.DOCKER_WORKDIR,
-                                           host_config=host_config)
-    except (RequestException, DockerException) as e:
-        if isinstance(e, APIError) and e.response.status_code == 409:
-            log.info("The container with the given name is already created",
-                     name=name)
-            c = name
-        else:
-            log.exception("Failed to create a sandbox container")
-            raise exceptions.DockerError(str(e))
-    log = log.bind(container=c)
-    log.info("Sandbox container created")
-    if workdir and not workdir.node:
-        node_name = _inspect_container_node(c)
-        if node_name:
-            # Assign a Swarm node name to the working directory to run
-            # subsequent containers on this same node.
-            workdir.node = node_name
-            log.info("Assigned Swarm node to the working directory",
-                     workdir=workdir)
-    if files:
-        _write_files(c, files)
-
-    result = {
-        'exit_code': None,
-        'stdout': b'',
-        'stderr': b'',
-        'duration': None,
-        'timeout': False,
-        'oom_killed': False,
-    }
-    try:
-        stdout, stderr = utils.docker_communicate(c, stdin=stdin,
-                                                  timeout=limits['realtime'])
-    except TimeoutError:
-        log.info("Sandbox realtime limit exceeded",
-                 realtime=limits['realtime'])
-        result['timeout'] = True
-    except (RequestException, DockerException, OSError) as e:
-        log.exception("Sandbox runtime error")
-        raise exceptions.DockerError(str(e))
-    else:
-        log.info("Sandbox container exited")
-        state = _inspect_container_state(c)
-        result.update(stdout=stdout, stderr=stderr, **state)
-        if (utils.is_killed_by_sigkill_or_sigxcpu(state['exit_code']) and
-                not state['oom_killed']):
-            # SIGKILL/SIGXCPU is sent but not by out of memory killer
-            result['timeout'] = True
-    log.info("Sandbox run result", result=utils.truncate_result(result))
-
-    log.info("Cleaning up the sandbox")
-    _cleanup_sandbox(c)
-    log.info("Sandbox cleaned up")
-    return result
-
-
-def _cleanup_sandbox(container):
-    docker_client = utils.get_docker_client()
-    try:
-        docker_client.remove_container(container, v=True, force=True)
-    except (RequestException, DockerException):
-        # TODO: handle 500 Driver aufs failed to remove root filesystem
-        logger.exception("Failed to remove the sandbox container",
-                         container=container)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import pytest
 import structlog
 
 import epicbox
+from epicbox import sandboxes
 from epicbox.rpcapi import EpicBoxAPI
 from epicbox.utils import get_docker_client
 
@@ -60,7 +61,8 @@ def configure(profile, profile_read_only, docker_url, base_workdir):
 
 
 @pytest.fixture(scope='session', autouse=True)
-def cleanup_test_containers(docker_client):
+def isolate_and_cleanup_test_containers(docker_client):
+    sandboxes._SANDBOX_NAME_PREFIX = 'epicbox-test-'
     yield
     test_containers = docker_client.containers(
         filters={'name': 'epicbox-test'}, all=True)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,11 @@
+def is_docker_swarm(client):
+    """Check if the client connected to a Docker Swarm cluster."""
+    docker_version = client.version()['Version']
+    return docker_version.startswith('swarm')
+
+
+def get_swarm_nodes(client):
+    system_status = client.info()['SystemStatus']
+    if not system_status:
+        return []
+    return list(map(lambda node: node[0].strip(), system_status[4::9]))


### PR DESCRIPTION
Add new API functions:
* `create` to create a new sandbox container;
* `start` to start a created sandbox container;
* `destroy` to destroy a sandbox container.

A sandbox object can be used as a context manager to destroy the sandbox upon completion of `with` block.
Refactor `run` to use the `create` context manager and `start`.